### PR TITLE
config: allow for override of signup template

### DIFF
--- a/invenio_userprofiles/ext.py
+++ b/invenio_userprofiles/ext.py
@@ -79,8 +79,10 @@ class InvenioUserProfiles(object):
             app.config.get('SETTINGS_TEMPLATE',
                            'invenio_userprofiles/settings/base.html'))
 
-        app.config['SECURITY_REGISTER_USER_TEMPLATE'] = \
-            'invenio_userprofiles/register_user.html'
+        app.config.setdefault(
+            'SECURITY_REGISTER_USER_TEMPLATE',
+            app.config.get('SECURITY_REGISTER_USER_TEMPLATE',
+                           'invenio_userprofiles/register_user.html'))
 
         if app.config['USERPROFILES_EXTEND_SECURITY_FORMS']:
             security_ext = app.extensions['security']


### PR DESCRIPTION
* FIX Fixes configuration of SECURITY_REGISTER_USER_TEMPLATE
  so that it can be overridden in the parent application. (closes #20)

Signed-off-by: Eamonn Maguire <eamonnmag@gmail.com>