### PR TITLE
forms: fix for incorrect template overriding

### DIFF
--- a/invenio_userprofiles/ext.py
+++ b/invenio_userprofiles/ext.py
@@ -79,12 +79,17 @@ class InvenioUserProfiles(object):
             app.config.get('SETTINGS_TEMPLATE',
                            'invenio_userprofiles/settings/base.html'))
 
-        app.config.setdefault(
-            'SECURITY_REGISTER_USER_TEMPLATE',
-            app.config.get('SECURITY_REGISTER_USER_TEMPLATE',
-                           'invenio_userprofiles/register_user.html'))
-
         if app.config['USERPROFILES_EXTEND_SECURITY_FORMS']:
+            app.config.setdefault(
+                'USERPROFILES_REGISTER_USER_BASE_TEMPLATE',
+                app.config.get(
+                    'SECURITY_REGISTER_USER_TEMPLATE',
+                    'invenio_accounts/register_user.html'
+                )
+            )
+            app.config['SECURITY_REGISTER_USER_TEMPLATE'] = \
+                'invenio_userprofiles/register_user.html'
+
             security_ext = app.extensions['security']
             security_ext.confirm_register_form = confirm_register_form_factory(
                 security_ext.confirm_register_form)

--- a/invenio_userprofiles/templates/invenio_userprofiles/register_user.html
+++ b/invenio_userprofiles/templates/invenio_userprofiles/register_user.html
@@ -23,7 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 #}
 
-{%- extends "invenio_accounts/register_user.html" %}
+{%- extends config.USERPROFILES_REGISTER_USER_BASE_TEMPLATE %}
 
 {% from "invenio_accounts/_macros.html" import render_field %}
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -55,6 +55,10 @@ def test_profile_in_registration(base_app):
         profile_url = url_for('invenio_userprofiles.profile')
 
     with app.test_client() as client:
+        resp = client.get(register_url)
+        assert 'profile.username' in resp.get_data(as_text=True)
+        assert 'profile.full_name' in resp.get_data(as_text=True)
+
         data = {
             'email': 'test_user@example.com',
             'password': 'test_password',


### PR DESCRIPTION
* FIX Registration template is no longer overridden when UserProfiles
  has been configured to not extend the registration form. (closes #21)

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>