### PR TITLE
templates: profile

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,13 +27,14 @@ from __future__ import print_function
 import os
 
 import sphinx.environment
-from docutils.utils import get_source_line
+
+_warn_node_old = sphinx.environment.BuildEnvironment.warn_node
 
 
-def _warn_node(self, msg, node):
+def _warn_node(self, msg, *args, **kwargs):
     """Do not warn on external images."""
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        _warn_node_old(self, msg, *args, **kwargs)
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 

--- a/invenio_userprofiles/templates/invenio_userprofiles/settings/profile.html
+++ b/invenio_userprofiles/templates/invenio_userprofiles/settings/profile.html
@@ -30,7 +30,7 @@
 {% set panel_icon = "fa fa-user" %}
 
 {%- block settings_form %}
-{%- if not current_user.confirmed_at %}
+{%- if security.confirmable and not current_user.confirmed_at %}
 <form method="POST" role="form">
 {{ verification_form.csrf_token }}
 <div class="alert alert-warning">


### PR DESCRIPTION
 * FIX Fixes issue that caused the profile template to display the
 	 `resend verification email` button, even if `security.confirmable` is set
 	 to `False`.

 * Also updates sphinx.