### PR TITLE
forms: change username from upper/lower

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,5 +27,6 @@ Authors
 
 User profiles module for Invenio.
 
-- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
+- Orestis Melkonian <melkon.or@gmail.com>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>

--- a/examples/app.py
+++ b/examples/app.py
@@ -70,7 +70,8 @@ from invenio_mail import InvenioMail
 from wtforms.i18n import messages_path
 
 from invenio_userprofiles import InvenioUserProfiles
-from invenio_userprofiles.views import blueprint_init
+from invenio_userprofiles.views import blueprint as blueprint2
+from invenio_userprofiles.views import blueprint_api_init, blueprint_ui_init
 
 try:
     pkg_resources.get_distribution('invenio_assets')
@@ -109,7 +110,9 @@ if INVENIO_THEME_AVAILABLE:
 InvenioAccounts(app)
 app.register_blueprint(blueprint)
 InvenioUserProfiles(app)
-app.register_blueprint(blueprint_init)
+app.register_blueprint(blueprint2)
+app.register_blueprint(blueprint_api_init)
+app.register_blueprint(blueprint_ui_init)
 InvenioAdmin(app, permission_factory=lambda x: x,
              view_class_factory=lambda x: x)
 

--- a/invenio_userprofiles/forms.py
+++ b/invenio_userprofiles/forms.py
@@ -77,9 +77,10 @@ class ProfileForm(Form):
             raise ValidationError(e)
 
         try:
-            UserProfile.get_by_username(field.data)
+            user_profile = UserProfile.get_by_username(field.data)
             if current_userprofile.is_anonymous or \
-                    field.data != current_userprofile.username:
+                    (current_userprofile.user_id != user_profile.user_id and
+                     field.data != current_userprofile.username):
                 # NOTE: Form validation error.
                 raise ValidationError(_('Username already exists.'))
         except NoResultFound:

--- a/invenio_userprofiles/views.py
+++ b/invenio_userprofiles/views.py
@@ -90,7 +90,7 @@ def userprofile(value):
     return UserProfile.get_by_userid(int(value))
 
 
-@blueprint.route('', methods=['GET', 'POST'])
+@blueprint.route('/', methods=['GET', 'POST'])
 @login_required
 @register_menu(
     blueprint, 'settings.profile',


### PR DESCRIPTION
 * FIX Fixes issue when a user changes only the case of his username and an
 	 error was raised, stating that `Username already exists`.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>