### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-UserProfiles.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-userprofiles
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/examples/app.py
+++ b/examples/app.py
@@ -45,8 +45,8 @@ Create the database and add a user:
    $ mkdir instance
    $ flask -a app.py db init
    $ flask -a app.py db create
-   $ flask -a app.py users create info@invenio-software.org -a
-   $ flask -a app.py users create another@invenio-software.org -a
+   $ flask -a app.py users create info@inveniosoftware.org -a
+   $ flask -a app.py users create another@inveniosoftware.org -a
 
 Run the development server:
 

--- a/invenio_userprofiles/translations/da/LC_MESSAGES/messages.po
+++ b/invenio_userprofiles/translations/da/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-userprofiles 1.0.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2016-01-20 08:16+0100\n"
 "PO-Revision-Date: 2015-11-24 13:19+0100\n"
 "Last-Translator: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>\n"

--- a/invenio_userprofiles/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_userprofiles/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-userprofiles 1.0.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-11-27 01:17+0100\n"
 "PO-Revision-Date: 2015-11-24 13:19+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = invenio_userprofiles/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_userprofiles/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
     keywords='invenio profile account user',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-userprofiles',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>