### PR TITLE
models: extend model to include an open metadata field

### DIFF
--- a/invenio_userprofiles/alembic/c25ef2c50ffa_create_userprofiles_tables.py
+++ b/invenio_userprofiles/alembic/c25ef2c50ffa_create_userprofiles_tables.py
@@ -25,6 +25,7 @@
 
 from alembic import op
 import sqlalchemy as sa
+import sqlalchemy_utils
 
 
 # revision identifiers, used by Alembic.
@@ -42,6 +43,10 @@ def upgrade():
         sa.Column('username', sa.String(length=255), nullable=True),
         sa.Column('displayname', sa.String(length=255), nullable=True),
         sa.Column('full_name', sa.String(length=255), nullable=False),
+        sa.Column('json_metadata', sqlalchemy_utils.JSONType().with_variant(
+            sa.dialects.postgresql.JSON(
+                none_as_null=True), 'postgresql',
+        ), nullable=True),
         sa.ForeignKeyConstraint(['user_id'], [u'accounts_user.id'], ),
         sa.PrimaryKeyConstraint('user_id'),
         sa.UniqueConstraint('username')

--- a/invenio_userprofiles/models.py
+++ b/invenio_userprofiles/models.py
@@ -29,7 +29,9 @@ from __future__ import absolute_import, print_function
 from invenio_accounts.models import User
 from invenio_db import db
 from sqlalchemy import event
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy_utils.types import JSONType
 
 
 from .validators import validate_username
@@ -73,6 +75,16 @@ class UserProfile(db.Model):
 
     full_name = db.Column(db.String(255), nullable=False, default='')
     """Full name of person."""
+
+    json_metadata = db.Column(
+        JSONType().with_variant(
+            postgresql.JSON(none_as_null=True),
+            'postgresql',
+        ),
+        default=lambda: dict(),
+        nullable=True
+    )
+    """Store metadata in JSON format."""
 
     @hybrid_property
     def username(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -170,3 +170,36 @@ def test_create_profile_with_null(app):
 
         user = User.query.get(user_id)
         assert user.profile is None
+
+
+def test_create_profile_with_metadata(app):
+    """Test creation of a profile with JSON metadata."""
+    with app.app_context():
+        # Create a test user
+        user = User(
+            email='test@example.org',
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        user_id = user.id
+
+        profile = UserProfile()
+
+        # Create user profile
+        profile.first_name = 'Test'
+        profile.last_name = 'User'
+        profile.json_metadata = {"affiliation": "CERN"}
+        assert profile.first_name == 'Test'
+        assert profile.last_name == 'User'
+        assert profile.json_metadata == {"affiliation": "CERN"}
+
+        user.profile = profile
+
+        db.session.merge(user)
+        db.session.commit()
+
+        user = User.query.filter(User.id == user_id).one()
+        assert user.profile.first_name == 'Test'
+        assert user.profile.last_name == 'User'
+        assert user.profile.json_metadata == {"affiliation": "CERN"}


### PR DESCRIPTION
* Adds open JSON metadata field to user profiles to store additional information such as a user's affiliation