### PR TITLE
admin: remove create user profile option

### DIFF
--- a/invenio_userprofiles/admin.py
+++ b/invenio_userprofiles/admin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -38,25 +38,27 @@ class UserProfileView(ModelView):
     """Userprofiles view. Links User ID to user/full/display name."""
 
     can_view_details = True
+    can_create = False
     can_delete = False
 
     column_list = (
         'user_id',
-        'username',
         '_displayname',
         'full_name',
     )
 
-    form_columns = \
-        column_searchable_list = \
+    column_searchable_list = \
         column_filters = \
         column_details_list = \
         columns_sortable_list = \
         column_list
 
+    form_columns = ('username', 'full_name')
+
     column_labels = {
-        '_displayname': _('Display Name'),
+        '_displayname': _('Username'),
     }
+
 
 user_profile_adminview = {
     'model': UserProfile,

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -57,5 +57,5 @@ def test_admin(app):
                 follow_redirects=True
             )
             assert res.status_code == 200
-            assert b'Display Name' in (res.get_data())
+            assert b'Username' in (res.get_data())
             assert b'Full Name' in (res.get_data())


### PR DESCRIPTION
* Uses just `_displayname` for listing users since `username` property
  is retrieving `_displayname` behind the scenes. `_displayname` has
  been chosen because it allows sorting.

* Restricts the edition to `username` and `full_name` since editing
  `user_id` is error prone and `_displayname` shouldn't be changed
  (it is handled internally).

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>