### PR TITLE
form: fix already existing user validation logic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,33 +36,22 @@ jobs:
 
           include:
           - db-service: postgresql9
-            DB: postgresql
-            POSTGRESQL_VERSION: POSTGRESQL_9_LATEST
-            SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://invenio:invenio@localhost:5432/invenio"
+            DB: postgresql9
             EXTRAS: "all,postgresql"
 
           - db-service: postgresql11
-            DB: postgresql
-            POSTGRESQL_VERSION: POSTGRESQL_11_LATEST
-            SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://invenio:invenio@localhost:5432/invenio"
+            DB: postgresql9
             EXTRAS: "all,postgresql"
 
           - db-service: mysql5
-            DB: mysql
-            MYSQL_VERSION: MYSQL_5_LATEST
-            SQLALCHEMY_DATABASE_URI: "mysql+pymysql://invenio:invenio@localhost:3306/invenio"
+            DB: mysql5
             EXTRAS: "all,mysql"
 
           - db-service: mysql8
-            DB: mysql
-            MYSQL_VERSION: MYSQL_8_LATEST
-            SQLALCHEMY_DATABASE_URI: "mysql+pymysql://invenio:invenio@localhost:3306/invenio"
+            DB: mysql8
             EXTRAS: "all,mysql"
 
     env:
-      SQLALCHEMY_DATABASE_URI: ${{matrix.SQLALCHEMY_DATABASE_URI}}
-      POSTGRESQL_VERSION: ${{matrix.POSTGRESQL_VERSION}}
-      MYSQL_VERSION: ${{matrix.MYSQL_VERSION}}
       DB: ${{ matrix.DB }}
 
     steps:

--- a/invenio_userprofiles/api.py
+++ b/invenio_userprofiles/api.py
@@ -29,13 +29,13 @@ def _get_current_userprofile():
     if current_user.is_anonymous:
         return AnonymousUserProfile()
 
-    profile = g.get(
-        'userprofile',
-        UserProfile.get_by_userid(current_user.get_id()))
+    profile = getattr(
+        g, 'userprofile', UserProfile.get_by_userid(current_user.get_id()))
 
     if profile is None:
         profile = UserProfile(user_id=int(current_user.get_id()))
         g.userprofile = profile
+
     return profile
 
 

--- a/invenio_userprofiles/forms.py
+++ b/invenio_userprofiles/forms.py
@@ -65,12 +65,25 @@ class ProfileForm(FlaskForm):
             raise ValidationError(e)
 
         try:
+            # Check if username is already taken (if the username is *not*
+            # found a NoResultFound exception is raised).
             user_profile = UserProfile.get_by_username(field.data)
-            if current_userprofile.is_anonymous or \
-                    (current_userprofile.user_id != user_profile.user_id and
-                     field.data != current_userprofile.username):
-                # NOTE: Form validation error.
-                raise ValidationError(_('Username already exists.'))
+
+            # NOTE: Form validation error.
+            msg = _('Username already exists.')
+
+            if current_userprofile.is_anonymous:
+                # We are handling a new sign up (i.e. anonymous user) AND a
+                # the username already exists. Fail.
+                raise ValidationError(msg)
+            else:
+                # We are handling a user editing their profile AND a
+                # the username already exists.
+                is_same_user = \
+                    current_userprofile.user_id == user_profile.user_id
+                if not is_same_user:
+                    # Username already taken by another user.
+                    raise ValidationError(msg)
         except NoResultFound:
             return
 

--- a/invenio_userprofiles/forms.py
+++ b/invenio_userprofiles/forms.py
@@ -68,7 +68,6 @@ class ProfileForm(FlaskForm):
             # Check if username is already taken (if the username is *not*
             # found a NoResultFound exception is raised).
             user_profile = UserProfile.get_by_username(field.data)
-
             # NOTE: Form validation error.
             msg = _('Username already exists.')
 
@@ -80,7 +79,7 @@ class ProfileForm(FlaskForm):
                 # We are handling a user editing their profile AND a
                 # the username already exists.
                 is_same_user = \
-                    current_userprofile.user_id == user_profile.user_id
+                    current_user.id == user_profile.user_id
                 if not is_same_user:
                     # Username already taken by another user.
                     raise ValidationError(msg)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -18,14 +18,13 @@ set -o nounset
 
 # Always bring down docker services
 function cleanup() {
-    docker-services-cli down
+    eval "$(docker-services-cli down --env)"
 }
 trap cleanup EXIT
 
-pydocstyle invenio_userprofiles
 python -m check_manifest --ignore ".*-requirements.txt"
-sphinx-build -qnNW docs docs/_build/html # Fails due to intersphinx invenio-accounts 403
-docker-services-cli up ${DB}
+sphinx-build -qnNW docs docs/_build/html
+eval "$(docker-services-cli up --db ${DB:-postgresql} --env)"
 python -m pytest
 tests_exit_code=$?
 exit "$tests_exit_code"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -183,7 +183,7 @@ def test_profile_name_exists(app):
 
         resp = client.post(profile_url, data=data)
         assert resp.status_code == 200
-        assert 'has-error' not in resp.get_data(as_text=True)
+        assert 'Username already exists.' in resp.get_data(as_text=True)
 
 
 def test_send_verification_form(app):


### PR DESCRIPTION
**THIS IS IN REVIEW TO GET A SANITY CHECK**

- Original problem: Test were failing because it was not getting a "User already exists" but a "Confirm email" (which is not an error).
- Digging a bit I think the logic of the validation is not correct:
    - Raise error when anonymous --> Fine
    - Raise error when userid is different and username is different, makes no sense to me. I think it should be *raise an error when user id is different and user name is **the same***.
- When making this change, the test fails at another point, digging a bit I noticed that *it does not fail* (which is not expected* because the `current_userprofile.userid` is *always* `1`. This means that the login/signup of the second user is not working or not updating the context for some reason.

Closes #116 