### PR TITLE
Add option to make user profiles read-only

### DIFF
--- a/invenio_userprofiles/config.py
+++ b/invenio_userprofiles/config.py
@@ -28,3 +28,6 @@ USERPROFILES_BASE_TEMPLATE = None
 
 USERPROFILES_SETTINGS_TEMPLATE = None
 """Settings base templates for user profile module."""
+
+USERPROFILES_READ_ONLY = False
+"""Make the user profiles read-only."""

--- a/invenio_userprofiles/templates/invenio_userprofiles/settings/_macros.html
+++ b/invenio_userprofiles/templates/invenio_userprofiles/settings/_macros.html
@@ -7,11 +7,11 @@
   under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-{% macro render_field(field, icon="", placeholder='', autofocus=False) %}
+{% macro render_field(field, icon="", placeholder='', autofocus=False, enabled=True) %}
   <div class="form-group {% if icon %} has-feedback{% endif %}{% if field.errors %} has-error{% endif %}">
     {{ field.label }}
     {%- set extras = dict(autofocus="") if autofocus else dict() %}
-    {{field(class_="form-control", placeholder=placeholder, **extras)}}
+    {{field(class_="form-control", disabled=not enabled, placeholder=placeholder, **extras)}}
     {%- if icon %}
     <i class="{{icon}} form-control-feedback" aria-hidden="true" ></i>
     {%- endif %}

--- a/invenio_userprofiles/templates/invenio_userprofiles/settings/profile.html
+++ b/invenio_userprofiles/templates/invenio_userprofiles/settings/profile.html
@@ -24,17 +24,20 @@
 </form>
 {%- endif %}
 {%- set form = profile_form %}
+{%- set read_only = config.USERPROFILES_READ_ONLY %}
 <form method="POST" name="profile_form">
 {%- for field in form %}
 {%- if field.widget.input_type == 'hidden' %}
 {{ field() }}
-{%- else %}
-{{ render_field(field, autofocus=True, placeholder=field.label.text) }}
+{%- elif not read_only or "repeat" not in field.id %}
+{{ render_field(field, autofocus=True, enabled=not read_only, placeholder=field.label.text) }}
 {%- endif %}
 {%- endfor %}
+{%- if not read_only %}
 <div class="form-actions">
   <a href="." class="btn btn-default"><i class="fa fa-times"></i> {{ _('Cancel') }}</a>
   <button type="submit" name="submit" value="profile" class="btn btn-primary"><i class="fa fa-check"></i> {{ _('Update profile') }}</button>
 </div>
+{%- endif %}
 </form>
 {%- endblock settings_form %}

--- a/invenio_userprofiles/templates/semantic-ui/invenio_userprofiles/settings/_macros.html
+++ b/invenio_userprofiles/templates/semantic-ui/invenio_userprofiles/settings/_macros.html
@@ -7,11 +7,11 @@
   under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-{% macro render_field(field, icon="", placeholder='', autofocus=False) %}
+{% macro render_field(field, icon="", placeholder='', autofocus=False, enabled=True) %}
   <div class="field {% if field.errors %}error{% endif %}">
     {{ field.label }}
     {%- set extras = dict(autofocus="") if autofocus else dict() %}
-    {{field(class_="form-control", placeholder=placeholder, **extras)}}
+    {{field(class_="form-control", disabled=not enabled, placeholder=placeholder, **extras)}}
     {%- if icon %}
     <i class="{{icon}}" aria-hidden="true" ></i>
     {%- endif %}

--- a/invenio_userprofiles/templates/semantic-ui/invenio_userprofiles/settings/profile.html
+++ b/invenio_userprofiles/templates/semantic-ui/invenio_userprofiles/settings/profile.html
@@ -24,17 +24,20 @@
 </form>
 {%- endif %}
 {%- set form = profile_form %}
-<form method="POST" name="profile_form" class="ui form">
+{%- set read_only = config.USERPROFILES_READ_ONLY %}
+<form {% if not read_only %}method="POST"{% endif %} name="profile_form" class="ui form">
   {%- for field in form %}
   {%- if field.widget.input_type == 'hidden' %}
   {{ field() }}
-  {%- else %}
-  {{ render_field(field, autofocus=True, placeholder=field.label.text) }}
+  {%- elif not read_only or "repeat" not in field.id %}
+  {{ render_field(field, autofocus=True, enabled=not read_only, placeholder=field.label.text) }}
   {%- endif %}
   {%- endfor %}
+  {%- if not read_only %}
   <div class="form-actions">
     <a href="." class="ui button"><i class="close icon"></i> {{ _('Cancel') }}</a>
     <button type="submit" name="submit" value="profile" class="ui primary button"><i class="check icon"></i> {{ _('Update profile') }}</button>
   </div>
+  {%- endif %}
 </form>
 {%- endblock settings_form %}

--- a/invenio_userprofiles/views.py
+++ b/invenio_userprofiles/views.py
@@ -95,8 +95,9 @@ def profile():
     profile_form = profile_form_factory()
 
     # Process forms
+    is_read_only = current_app.config.get("USERPROFILES_READ_ONLY", False)
     form = request.form.get('submit', None)
-    if form == 'profile':
+    if form == 'profile' and not is_read_only:
         handle_profile_form(profile_form)
     elif form == 'verification':
         handle_verification_form(verification_form)
@@ -136,6 +137,9 @@ def handle_verification_form(form):
 
 def handle_profile_form(form):
     """Handle profile update form."""
+    if current_app.config.get("USERPROFILES_READ_ONLY", False):
+        return
+
     form.process(formdata=request.form)
 
     if form.validate_on_submit():

--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,13 @@ extras_require = {
         'invenio-mail>=1.0.0',
     ],
     'mysql': [
-        'invenio-db[mysql]>=1.0.5',
+        'invenio-db[mysql]>=1.0.9',
     ],
     'postgresql': [
-        'invenio-db[postgresql]>=1.0.5',
+        'invenio-db[postgresql]>=1.0.9',
     ],
     'sqlite': [
-        'invenio-db>=1.0.5',
+        'invenio-db>=1.0.9',
     ],
     'tests': tests_require,
 }

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'pytest-invenio>=1.4.0',
+    'pytest-invenio>=1.4.2',
+    'SQLAlchemy-Continuum>=1.2.1',
 ]
 
 extras_require = {
@@ -26,7 +27,7 @@ extras_require = {
         'invenio-admin>=1.2.0',
     ],
     'docs': [
-        'Sphinx>=1.4.2,<3.0.0',
+        'Sphinx>=3.0.0,<3.4.2',
         'invenio-mail>=1.0.0',
     ],
     'mysql': [
@@ -53,12 +54,13 @@ setup_requires = [
 ]
 
 install_requires = [
+    'Flask>=1.1.0,<2.0.0',
     'Flask-Breadcrumbs>=0.5.0',
     'Flask-Mail>=0.9.1',
     'Flask-Menu>=0.5.0',
     'Flask-WTF>=0.14.3',
     'invenio-accounts>=1.2.1',
-    'invenio-base>=1.2.2',
+    'invenio-base>=1.2.4',
     'invenio-i18n>=1.2.0',
     'invenio-theme>=1.3.4',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,13 +29,11 @@ from invenio_userprofiles import InvenioUserProfiles
 from invenio_userprofiles.views import blueprint_ui_init
 
 
-@pytest.yield_fixture()
-def base_app():
-    """Flask application fixture."""
-    instance_path = tempfile.mkdtemp()
-    base_app = Flask(__name__, instance_path=instance_path)
-
-    base_app.config.update(
+@pytest.fixture(scope='module')
+def app_config(app_config):
+    """Override pytest-invenio app_config fixture."""
+    app_config.update(
+        ACCOUNTS_LOCAL_LOGIN_ENABLED=True,
         ACCOUNTS_USE_CELERY=False,
         LOGIN_DISABLED=False,
         SECRET_KEY='testing_key',
@@ -46,6 +44,16 @@ def base_app():
         TESTING=True,
         WTF_CSRF_ENABLED=False,
     )
+
+    return app_config
+
+
+@pytest.yield_fixture()
+def base_app(app_config):
+    """Flask application fixture."""
+    instance_path = tempfile.mkdtemp()
+    base_app = Flask(__name__, instance_path=instance_path)
+    base_app.config.update(app_config)
 
     Babel(base_app)
     Mail(base_app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def base_app():
         TESTING=True,
         WTF_CSRF_ENABLED=False,
     )
+
     Babel(base_app)
     Mail(base_app)
     Menu(base_app)

--- a/tests/test_invenio_userprofile.py
+++ b/tests/test_invenio_userprofile.py
@@ -31,7 +31,8 @@ def test_init():
     """Test extension initialization."""
     app = Flask('testapp')
     app.config.update(
-        ACCOUNTS_USE_CELERY=False
+        ACCOUNTS_USE_CELERY=False,
+        SECRET_KEY="test_key",
     )
     Babel(app)
     Mail(app)
@@ -43,7 +44,8 @@ def test_init():
 
     app = Flask('testapp')
     app.config.update(
-        ACCOUNTS_USE_CELERY=False
+        ACCOUNTS_USE_CELERY=False,
+        SECRET_KEY="test_key",
     )
     Babel(app)
     Mail(app)


### PR DESCRIPTION
add option to make userprofiles read-only (useful when external auth services are used as source of truth)
closes #122 