### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 2.1.0. (released 2023-03-02)
+
+- remove deprecated flask_babelex imports
+- install invenio_i18n explicitly
+
 Version 2.0.5 (released 2022-12-14)
 
 - forms: add helper for preferences form

--- a/invenio_userprofiles/__init__.py
+++ b/invenio_userprofiles/__init__.py
@@ -30,7 +30,7 @@ from .api import current_userprofile
 from .ext import InvenioUserProfiles
 from .models import UserProfile, UserProfileProxy
 
-__version__ = "2.0.5"
+__version__ = "2.1.0"
 
 __all__ = (
     "__version__",

--- a/invenio_userprofiles/forms.py
+++ b/invenio_userprofiles/forms.py
@@ -9,10 +9,10 @@
 """Forms for user profiles."""
 
 from flask import current_app
-from flask_babelex import lazy_gettext as _
 from flask_login import current_user
 from flask_security.forms import email_required, email_validator, unique_user_email
 from flask_wtf import FlaskForm
+from invenio_i18n import lazy_gettext as _
 from wtforms import FormField, RadioField, StringField, SubmitField
 from wtforms.validators import (
     DataRequired,

--- a/invenio_userprofiles/validators.py
+++ b/invenio_userprofiles/validators.py
@@ -10,7 +10,7 @@
 
 import re
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 
 username_regex = re.compile("^[a-zA-Z][a-zA-Z0-9-_]{2}[a-zA-Z0-9-_]*$")
 """Username rules."""

--- a/invenio_userprofiles/views.py
+++ b/invenio_userprofiles/views.py
@@ -20,14 +20,14 @@ from flask import (
     request,
     url_for,
 )
-from flask_babelex import lazy_gettext as _
 from flask_breadcrumbs import register_breadcrumb
 from flask_login import current_user, login_required
 from flask_menu import register_menu
 from flask_security.confirmable import send_confirmation_instructions
 from invenio_db import db
+from invenio_i18n import LazyString
+from invenio_i18n import lazy_gettext as _
 from invenio_theme.proxies import current_theme_icons
-from speaklater import make_lazy_string
 
 from .forms import (
     EmailProfileForm,
@@ -98,7 +98,7 @@ def userprofile(value):
     # NOTE: Menu item text (icon replaced by a user icon).
     _(
         "%(icon)s Profile",
-        icon=make_lazy_string(lambda: f'<i class="{current_theme_icons.user}"></i>'),
+        icon=LazyString(lambda: f'<i class="{current_theme_icons.user}"></i>'),
     ),
     order=0,
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2022 CERN.
 # Copyright (C) 2021      TU Wien.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -29,6 +29,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     invenio-accounts>=2.0.0
+    invenio-i18n>=2.0.0
 
 [options.extras_require]
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,8 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0,<0.3.10
-    pytest-invenio~=1.4.7
+    pytest-black>=0.3.0
+    pytest-invenio>=1.4.7
     invenio-db[mysql,postgresql,versioning]>=1.0.14
     sphinx>=4.5
 admin =

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     invenio-accounts>=2.0.0
-    invenio-i18n>=2.0.0
+    invenio-i18n>=2.0.0,<3.0.0
 
 [options.extras_require]
 tests =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,12 @@ import tempfile
 
 import pytest
 from flask import Flask
-from flask_babelex import Babel
 from flask_mail import Mail
 from flask_menu import Menu
 from invenio_accounts import InvenioAccounts
 from invenio_accounts.views import blueprint as accounts_blueprint
 from invenio_db import InvenioDB, db
+from invenio_i18n import Babel
 from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 
 from invenio_userprofiles import InvenioUserProfiles

--- a/tests/test_invenio_userprofile.py
+++ b/tests/test_invenio_userprofile.py
@@ -10,11 +10,11 @@
 
 import pytest
 from flask import Flask
-from flask_babelex import Babel
 from flask_mail import Mail
 from flask_menu import Menu
 from invenio_accounts import InvenioAccounts
 from invenio_db import InvenioDB, db
+from invenio_i18n import Babel
 
 from invenio_userprofiles import InvenioUserProfiles
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -16,7 +16,7 @@ from invenio_accounts.models import User
 from test_validators import test_usernames
 
 from invenio_userprofiles import InvenioUserProfiles
-from invenio_userprofiles.views import blueprint_ui_init, userprofile
+from invenio_userprofiles.views import blueprint_ui_init
 
 
 def prefix(name, data):


### PR DESCRIPTION
- migrate: flask_babelex replaced by invenio_i18n
- setup: allow newest pytest-invenio, pytest-black

- NOTE flask-security-invenio, invenio-i18n, invenio-accounts, invenio-theme are necessary to make the tests green