### PR TITLE
Tests: check existing username case-insensitive

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -180,12 +180,12 @@ def test_profile_name_exists(app):
             profile_url,
             data=prefix(
                 "profile",
-                dict(username="existingname", full_name="Valid Name", affiliations=""),
+                dict(username="ExistingName", full_name="Valid Name", affiliations=""),
             ),
         )
         assert error_msg not in resp.get_data(as_text=True)
 
-    # Create another user and try setting username to same as above user.
+    # Create another user and try setting username to same as above user with a different case.
     with app.test_client() as client:
         sign_up(app, client)
         login(app, client)
@@ -197,7 +197,7 @@ def test_profile_name_exists(app):
             data=prefix(
                 "profile",
                 dict(
-                    username="existingname", full_name="Another name", affiliations=""
+                    username="eXISTINGnAME", full_name="Another name", affiliations=""
                 ),
             ),
             follow_redirects=True,


### PR DESCRIPTION
Fixes https://github.com/zenodo/ops/issues/326

:heart: Thank you for your contribution!

### Description

~~Usernames are enforced to be unique in the DB regardless of their case ([see related DB column and constraint definition](https://github.com/inveniosoftware/invenio-accounts/blob/master/invenio_accounts/alembic/eb9743315a9d_add_userprofile.py#L53-L66)).~~

~~This change applies the same validation at the registration of a user to avoid hitting the DB constraint which is then not well handled by Flask (users end up seeing an nginx 502 error).~~

This is a test-only pull request related to https://github.com/inveniosoftware/invenio-accounts/pull/476.
Here we only improve the test to make sure that `invenio-accounts` properly finds by usernames case-insensitively.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
