### PR TITLE
i18n: Unified gettext formatting

### DIFF
--- a/invenio_userprofiles/forms.py
+++ b/invenio_userprofiles/forms.py
@@ -60,9 +60,7 @@ class ProfileForm(FlaskForm):
         # NOTE: Form field label
         _("Username"),
         # NOTE: Form field help text
-        description=_("Required. {username_rules}").format(
-            username_rules=USERNAME_RULES
-        ),
+        description=_("Required. %(username_rules)s", username_rules=USERNAME_RULES),
         validators=[Length(max=50), DataRequired(message=_("Username not provided."))],
         filters=[strip_filter],
     )

--- a/invenio_userprofiles/views.py
+++ b/invenio_userprofiles/views.py
@@ -134,8 +134,9 @@ def handle_profile_form(form):
         flash(
             _(
                 "Profile was updated. We have sent a verification "
-                "email to {email}. Please check it."
-            ).format(email=current_user.email.lower()),
+                "email to %(email)s. Please check it.",
+                email=current_user.email.lower(),
+            ),
             category="success",
         )
     else:


### PR DESCRIPTION
### Description

Unified gettext formatting to consistently use “%(variable)s” placeholders for variables in formatted strings.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
