### PR TITLE
fix(validation): use invenio-accounts `validate_username` method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@
 Changes
 =======
 
+Version v5.1.0 (released 2026-02-26)
+
+- fix(validation): use invenio-accounts validate_username method
+- deprecated: validate_username method and username_regex + USERNAME_RULES constants
+
 Version v5.0.0 (released 2026-01-29)
 
 - chore(setup): bump dependencies

--- a/invenio_userprofiles/__init__.py
+++ b/invenio_userprofiles/__init__.py
@@ -32,7 +32,7 @@ from .api import current_userprofile
 from .ext import InvenioUserProfiles
 from .models import UserProfile, UserProfileProxy
 
-__version__ = "5.0.0"
+__version__ = "5.1.0"
 
 __all__ = (
     "__version__",

--- a/invenio_userprofiles/forms.py
+++ b/invenio_userprofiles/forms.py
@@ -8,13 +8,12 @@
 
 """Forms for user profiles."""
 
-import pytz
 from flask import current_app
 from flask_login import current_user
 from flask_security.forms import email_required, email_validator, unique_user_email
 from flask_wtf import FlaskForm
+from invenio_accounts.utils import validate_username
 from invenio_i18n import lazy_gettext as _
-from invenio_i18n.ext import InvenioI18N
 from werkzeug.local import LocalProxy
 from wtforms import (
     FormField,
@@ -22,7 +21,6 @@ from wtforms import (
     SelectField,
     StringField,
     SubmitField,
-    validators,
 )
 from wtforms.validators import (
     DataRequired,
@@ -33,7 +31,6 @@ from wtforms.validators import (
 )
 
 from .models import UserProfileProxy
-from .validators import USERNAME_RULES, validate_username
 
 
 def strip_filter(text):
@@ -59,8 +56,6 @@ class ProfileForm(FlaskForm):
     username = StringField(
         # NOTE: Form field label
         _("Username"),
-        # NOTE: Form field help text
-        description=_("Required. %(username_rules)s", username_rules=USERNAME_RULES),
         validators=[Length(max=50), DataRequired(message=_("Username not provided."))],
         filters=[strip_filter],
     )
@@ -78,6 +73,19 @@ class ProfileForm(FlaskForm):
         validators=[Length(max=255)],
         filters=[strip_filter],
     )
+
+    def __init__(self, formdata=..., **kwargs):
+        """Lazily set the description of the `username` field during initialisation.
+
+        The app context is not available at import time, so we can only get the config
+        after the app is ready.
+        """
+        super().__init__(formdata, **kwargs)
+
+        self.username.description = _(
+            "Required. %(username_rules)s",
+            username_rules=current_app.config["ACCOUNTS_USERNAME_RULES_TEXT"],
+        )
 
     def validate_username(self, field):
         """Wrap username validator for WTForms."""

--- a/invenio_userprofiles/validators.py
+++ b/invenio_userprofiles/validators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2026 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,28 +9,40 @@
 """Validators for user profiles."""
 
 import re
+import warnings
 
 from invenio_i18n import lazy_gettext as _
 
 username_regex = re.compile("^[a-zA-Z][a-zA-Z0-9-_]{2}[a-zA-Z0-9-_]*$")
-"""Username rules."""
+"""Deprecated. Use the `ACCOUNTS_USERNAME_REGEX` config variable in invenio_accounts instead.
+
+Username rules."""
 
 USERNAME_RULES = _(
     "Username must start with a letter, be at least three characters long and"
     " only contain alphanumeric characters, dashes and underscores."
 )
-"""Description of username validation rules.
+"""Deprecated. Use the `ACCOUNTS_USERNAME_RULES_TEXT` config variable in invenio_accounts instead.
+
+Description of username validation rules.
 
 .. note:: Used for both form help text and for form validation error."""
 
 
 def validate_username(username):
-    """Validate the username.
+    """Deprecated. Use invenio_accounts.utils.validate_username instead.
+
+    Validate the username.
 
     See :data:`~.username_regex` to know which rules are applied.
 
     :param username: A username.
     :raises ValueError: If validation fails.
     """
+    warnings.warn(
+        "invenio_userprofiles.validators.validate_username is deprecated and will be removed in "
+        "a future release. Please use invenio_accounts.utils.validate_username instead.",
+        DeprecationWarning,
+    )
     if not username_regex.match(username):
         raise ValueError(USERNAME_RULES)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -9,8 +9,7 @@
 """Tests for user profile validators."""
 
 import pytest
-
-from invenio_userprofiles.validators import validate_username
+from invenio_accounts.utils import validate_username
 
 test_usernames = {
     "valid": "Good-Name_9",


### PR DESCRIPTION
* Currently invenio-userprofiles specifies its own username validator with its own regex and error message. This cannot (easily) be overridden on the instance level since the values are hard coded.

* invenio-accounts [already has a validate_username method](https://github.com/inveniosoftware/invenio-accounts/blob/f97e700fe63807906398ca093e4cc497e3134b4d/invenio_accounts/utils.py#L237) which uses easily modifiable config variables. Since invenio-userprofiles depends on invenio-accounts, we can safely just use that existing method. The two config variables have default values and so will always be defined

* Invenio-Accounts has a slightly different regex to Invenio-Userprofiles:
  * [Invenio-Accounts](https://github.com/inveniosoftware/invenio-accounts/blob/f97e700fe63807906398ca093e4cc497e3134b4d/invenio_accounts/config.py#L325): `^[a-zA-Z][a-zA-Z0-9-_]{2,255}$`
  * [Invenio-Userprofiles](https://github.com/inveniosoftware/invenio-userprofiles/blob/0f5561c99bbe54603789e904318920e68918e5d6/invenio_userprofiles/validators.py#L15): `^[a-zA-Z][a-zA-Z0-9-_]{2}[a-zA-Z0-9-_]*$` which simplifies to `^[a-zA-Z][a-zA-Z0-9-_]{2,}$`

This simply means that with the Invenio-Accounts config there's a max limit of 256 characters, while for Invenio Userprofiles there is no **regex-specified** limit. Instead, the limit is 50 characters and is specified via the `wtforms` schema [here](https://github.com/inveniosoftware/invenio-userprofiles/blob/0f5561c99bbe54603789e904318920e68918e5d6/invenio_userprofiles/forms.py#L64). Therefore, we **do not need to override** the default regex from Invenio-Accounts in this repo. If an instance specifies its own `ACCOUNTS_USERNAME_REGEX `, that will be used in both Invenio-Accounts and Invenio-Userprofiles.